### PR TITLE
Fixing issue #69

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-elm",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "The Elm Architecture in Redux",
   "main": "lib/index.js",
   "files": [

--- a/src/matching/MatchingReducerFactory.js
+++ b/src/matching/MatchingReducerFactory.js
@@ -61,7 +61,7 @@ export default class MatchingReducerFactory {
           return appState;
         }
 
-        const parentId = action.matching ? action.matching.id : '';
+        const parentId = action.matching ? `${action.matching.id}.` : '';
         const parentWrap = action.matching ? action.matching.wrap : identity;
         const parentArgs = action.args ? action.args : {};
 

--- a/src/matching/matchers/matcher.js
+++ b/src/matching/matchers/matcher.js
@@ -16,22 +16,22 @@ export default pattern => {
         unwrappedType: action.type,
         args: {}
       };
-    } else {
-      const match = action.type.match(regexp);
-
-      if (match) {
-        const unwrappedType = match[1];
-
-        return {
-          id: `${pattern}.`,
-          wrap: type => `${pattern}.${type}`,
-          unwrappedType,
-          args: {}
-        };
-      } else {
-        return false;
-      }
     }
+
+    const match = action.type.match(regexp);
+
+    if (match) {
+      const unwrappedType = match[1];
+
+      return {
+        id: pattern,
+        wrap: type => `${pattern}.${type}`,
+        unwrappedType,
+        args: {}
+      };
+    }
+
+    return false;
   };
 };
 

--- a/test/matching/matcher.test.js
+++ b/test/matching/matcher.test.js
@@ -7,6 +7,7 @@ describe('matcher', () => {
     const result = matcher('Foo')({ type: 'Foo.Bar' });
     assert.equal(result.wrap('Qux'), 'Foo.Qux');
     assert.equal(result.unwrappedType, 'Bar');
+    assert.equal(result.id, 'Foo');
   });
 
   it('should not match when action does not start with pattern', () => {
@@ -20,6 +21,7 @@ describe('matcher', () => {
 
     assert.equal(result.unwrappedType, 'Foo');
     assert.equal(result.wrap(pattern), pattern);
+    assert.equal(result.id, 'Foo');
   });
 
   it('should not match the action there\'s no exact match nor unwrapping', () => {

--- a/test/matching/matchingReducer.test.js
+++ b/test/matching/matchingReducer.test.js
@@ -6,6 +6,7 @@ const Increment = 'Increment';
 const Decrement = 'Decrement';
 const INCREMENT_ACTION = { type: Increment };
 const DECREMENT_ACTION = { type: Decrement };
+const INCREMENT_ACTION_WITH_PARENT = { type: Increment, matching: { id: 'Parent', wrap: t => t } };
 
 const INITIAL_APP_STATE = 42;
 
@@ -49,5 +50,35 @@ describe('MatchingReducerFactory', () => {
     const referenceToMutatedState = counterReducer(state, { type: 'FooBar' });
 
     assert.equal(state, referenceToMutatedState);
+  });
+
+  it('should provide correct action matching id', () => {
+    let matchingResult;
+
+    const reducer = new MatchingReducerFactory(0)
+      .case(Increment, (appState, { matching }) => {
+        matchingResult = matching;
+        return appState + 1;
+      })
+      .toReducer();
+
+    reducer(undefined, INCREMENT_ACTION);
+
+    assert.equal(matchingResult.id, Increment);
+  });
+
+  it('should provide correct action matching id when action parent exists', () => {
+    let matchingResult;
+
+    const reducer = new MatchingReducerFactory(0)
+      .case(Increment, (appState, { matching }) => {
+        matchingResult = matching;
+        return appState + 1;
+      })
+      .toReducer();
+
+    reducer(undefined, INCREMENT_ACTION_WITH_PARENT);
+
+    assert.equal(matchingResult.id, `Parent.${Increment}`);
   });
 });


### PR DESCRIPTION
Issue #69 - removes extra '.' from matching.id

Inconsistency between how sagaId populated for mount and unmount
actions leads to mounting sagas with `Foo.Bar.` while for unmount
it uses `Foo.Bar`

Using `Foo.Bar.` seems wrong as delimiters should be explicit
and not implicitly set on id.